### PR TITLE
Test enhancement

### DIFF
--- a/tests/OverloadableTest.php
+++ b/tests/OverloadableTest.php
@@ -11,7 +11,7 @@ class OverloadableTest extends TestCase
 {
     private $overloadable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->overloadable = new TestOverloadable;
     }


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixtures](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method should be `protected` with native `void` type hint.
- Add the `public` method for `it_overloads` method.