### PR TITLE
fix deprecated message when running tests on PHP74

### DIFF
--- a/src/OverloadedMethodCandidate.php
+++ b/src/OverloadedMethodCandidate.php
@@ -77,7 +77,7 @@ class OverloadedMethodCandidate
                 return '*';
             }
 
-            return $parameter->getType()->__toString();
+            return $parameter->getType()->getName();
         }, $reflectionFunction->getParameters());
 
         return $this->normalizeTypes($types);


### PR DESCRIPTION
When running tests on PHP7.4, the following error message appears:

`Function ReflectionType::__toString() is deprecated`

This PR fixes that.